### PR TITLE
fix(redis): Make ObjectMapper injectable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 *.iml
 *.iws
 /.gradle/
+.idea

--- a/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
+++ b/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.config
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.netflix.spinnaker.q.metrics.EventPublisher
 import com.netflix.spinnaker.q.redis.RedisDeadMessageHandler
 import com.netflix.spinnaker.q.redis.RedisQueue
@@ -58,12 +61,14 @@ open class RedisQueueConfiguration {
     redisQueueProperties: RedisQueueProperties,
     clock: Clock,
     deadMessageHandler: RedisDeadMessageHandler,
-    publisher: EventPublisher
+    publisher: EventPublisher,
+    redisQueueObjectMapper: ObjectMapper
   ) =
     RedisQueue(
       queueName = redisQueueProperties.queueName,
       pool = redisPool,
       clock = clock,
+      mapper = redisQueueObjectMapper,
       deadMessageHandler = deadMessageHandler,
       publisher = publisher,
       ackTimeout = Duration.ofSeconds(redisQueueProperties.ackTimeoutSeconds.toLong())
@@ -79,4 +84,11 @@ open class RedisQueueConfiguration {
       pool = redisPool,
       clock = clock
     )
+
+  @Bean
+  @ConditionalOnMissingBean
+  open fun redisQueueObjectMapper(): ObjectMapper =
+    ObjectMapper()
+      .registerModule(KotlinModule())
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 }

--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.q.redis
 
-import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.google.common.hash.Hashing
 import com.netflix.spinnaker.q.AttemptsAttribute
 import com.netflix.spinnaker.q.MaxAttemptsAttribute
@@ -46,14 +44,11 @@ class RedisQueue(
   private val pool: Pool<Jedis>,
   private val clock: Clock,
   private val lockTtlSeconds: Int = 10,
+  private val mapper: ObjectMapper,
   override val ackTimeout: TemporalAmount = Duration.ofMinutes(1),
   override val deadMessageHandler: (Queue, Message) -> Unit,
   override val publisher: EventPublisher
 ) : MonitorableQueue {
-
-  private val mapper = ObjectMapper()
-    .registerModule(KotlinModule())
-    .disable(FAIL_ON_UNKNOWN_PROPERTIES)
 
   private val log: Logger = LoggerFactory.getLogger(javaClass)
 

--- a/keiko-redis/src/test/kotlin/com/netflix/spinnaker/q/redis/RedisQueueTest.kt
+++ b/keiko-redis/src/test/kotlin/com/netflix/spinnaker/q/redis/RedisQueueTest.kt
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.q.redis
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
 import com.netflix.spinnaker.q.DeadMessageCallback
 import com.netflix.spinnaker.q.QueueTest
@@ -46,7 +49,10 @@ private val createQueue = { clock: Clock,
     deadMessageHandler = deadLetterCallback,
     publisher = publisher ?: (object : EventPublisher {
       override fun publishEvent(event: QueueEvent) {}
-    })
+    }),
+    mapper = ObjectMapper()
+      .registerModule(KotlinModule())
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
   )
 }
 


### PR DESCRIPTION
For use in keel, we need to provide a different ObjectMapper that knows how to deserialize intent messages.