### PR TITLE
feat(core): Switch serialization to use names instead of classes

### DIFF
--- a/keiko-core/build.gradle
+++ b/keiko-core/build.gradle
@@ -2,6 +2,7 @@ apply from: "$rootDir/gradle/spek.gradle"
 
 dependencies {
   compile "com.fasterxml.jackson.core:jackson-annotations:${spinnaker.version("jackson")}"
+  compile "com.fasterxml.jackson.core:jackson-databind:${spinnaker.version("jackson")}"
   compile "org.springframework:spring-context:${spinnaker.version("spring")}"
 
   testCompile project(":keiko-test-common")

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/Message.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/Message.kt
@@ -17,14 +17,17 @@
 package com.netflix.spinnaker.q
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME
+import com.fasterxml.jackson.annotation.JsonTypeName
+
+const val JSON_NAME_PROPERTY = "kind"
 
 /**
  * Implemented by all messages used with the [Queue]. Sub-types should be simple
  * immutable value types such as Kotlin data classes or _Lombok_ `@Value`
  * classes.
  */
-@JsonTypeInfo(use = CLASS) abstract class Message {
+@JsonTypeInfo(use = NAME, property = JSON_NAME_PROPERTY) abstract class Message {
   // TODO: this type should be immutable
   val attributes: MutableList<Attribute> = mutableListOf()
 
@@ -48,15 +51,17 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id.CLASS
 /**
  * The base type for message metadata attributes.
  */
-@JsonTypeInfo(use = CLASS)
+@JsonTypeInfo(use = NAME, property = JSON_NAME_PROPERTY)
 interface Attribute
 
 /**
  * An attribute representing the maximum number of retries for a message.
  */
+@JsonTypeName("maxAttempts")
 data class MaxAttemptsAttribute(val maxAttempts: Int = -1) : Attribute
 
 /**
  * An attribute representing the number of times a message has been retried.
  */
+@JsonTypeName("attempts")
 data class AttemptsAttribute(var attempts: Int = 0) : Attribute

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/migration/FqnTypeInfoSerializationMigrator.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/migration/FqnTypeInfoSerializationMigrator.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.migration
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.q.JSON_NAME_PROPERTY
+import org.slf4j.LoggerFactory
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * This migrator converts Keiko messages & attributes to use JsonTypeInfo to use NAME on a "kind" property.
+ *
+ * NOTE: Running this migrator is unnecessary except on services that were using Keiko before 1.5.3, or Orca
+ * before it was moved over to Keiko.
+ */
+class FqnTypeInfoSerializationMigrator : SerializationMigrator {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  private val migrated = AtomicInteger(0)
+  private var lastReport: LocalTime? = null
+
+  override fun migrate(json: MutableMap<String, Any?>): MutableMap<String, Any?> {
+    migrateFqnClass(json)
+
+    if (json.containsKey("attributes") && json["attributes"] is List<*>) {
+      (json["attributes"] as List<*>)
+        .filterIsInstance<MutableMap<String, Any?>>()
+        .forEach { migrateFqnClass(it) }
+    }
+
+    return json
+  }
+
+  override fun report() {
+    log.info(
+      "Migrated {} objects since {}",
+      migrated.get(),
+      if (lastReport == null) "startup" else lastReport!!.format(DateTimeFormatter.ISO_TIME)
+    )
+
+    migrated.set(0)
+    lastReport = LocalTime.now()
+  }
+
+  private fun migrateFqnClass(json: MutableMap<String, Any?>) {
+    if (json.containsKey("@class")) {
+      migrated.incrementAndGet()
+
+      val cls = javaClass.classLoader.loadClass(json["@class"].toString())
+      val typeInfoName = cls.annotations.filterIsInstance<JsonTypeName>().firstOrNull() ?: return
+
+      json.apply {
+        remove("@class")
+        put(JSON_NAME_PROPERTY, typeInfoName.value)
+      }
+    }
+  }
+}

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/migration/SerializationMigrator.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/migration/SerializationMigrator.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.q.migration
 
-package com.netflix.spinnaker.config
+/**
+ * Provides a generic interface for handling jackson deserialization errors
+ * and migrating messages to a new, supported format.
+ */
+interface SerializationMigrator {
 
-import org.springframework.boot.context.properties.ConfigurationProperties
-
-@ConfigurationProperties("keiko.queue")
-class QueueProperties {
-  var handlerCorePoolSize: Int = 20
-  var handlerMaxPoolSize: Int = 20
+  fun migrate(json: MutableMap<String, Any?>): MutableMap<String, Any?>
+  fun report()
 }

--- a/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/QueueProcessorTest.kt
+++ b/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/QueueProcessorTest.kt
@@ -16,13 +16,24 @@
 
 package com.netflix.spinnaker.q
 
+import com.fasterxml.jackson.annotation.JsonTypeName
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.throws
 import com.netflix.spinnaker.mockito.doStub
 import com.netflix.spinnaker.q.metrics.EventPublisher
 import com.netflix.spinnaker.q.metrics.NoHandlerCapacity
 import com.netflix.spinnaker.spek.and
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.doThrow
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.isA
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.whenever
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
@@ -239,12 +250,15 @@ object QueueProcessorTest : Spek({
   }
 })
 
+@JsonTypeName("simple")
 data class SimpleMessage(val payload: String) : Message()
 
 sealed class ParentMessage : Message()
 
+@JsonTypeName("child")
 data class ChildMessage(val payload: String) : ParentMessage()
 
+@JsonTypeName("unsupported")
 data class UnsupportedMessage(val payload: String) : Message()
 
 class BlockingThreadExecutor : Executor {

--- a/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/migration/FqnTypeInfoSerializationMigratorTest.kt
+++ b/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/migration/FqnTypeInfoSerializationMigratorTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.migration
+
+import com.netflix.spinnaker.spek.shouldEqual
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+object FqnTypeInfoSerializationMigratorTest : Spek({
+
+  val migrator = FqnTypeInfoSerializationMigrator()
+
+  describe("a Jackson TypeInfoName serialization migrator") {
+    it("should do nothing if a @class property does not exist on a message") {
+      val message = mutableMapOf<String, Any?>(
+        "kind" to "example",
+        "intent" to mutableMapOf(
+          "foo" to "bar"
+        )
+      )
+
+      migrator.migrate(message) shouldEqual message
+    }
+
+    it("should convert a @class property to a name-property object") {
+      val message = mutableMapOf<String, Any?>(
+        "@class" to "com.netflix.spinnaker.q.SimpleMessage",
+        "intent" to mutableMapOf(
+          "foo" to "bar"
+        ),
+        "attributes" to listOf(
+          mutableMapOf(
+            "@class" to "com.netflix.spinnaker.q.AttemptsAttribute",
+            "value" to 1
+          )
+        )
+      )
+      val expected = mutableMapOf<String, Any?>(
+        "kind" to "simple",
+        "intent" to mutableMapOf(
+          "foo" to "bar"
+        ),
+        "attributes" to listOf(
+          mutableMapOf(
+            "kind" to "attempts",
+            "value" to 1
+          )
+        )
+      )
+
+      migrator.migrate(message) shouldEqual expected
+    }
+  }
+})

--- a/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/ObjectMapperSubtypeProperties.kt
+++ b/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/ObjectMapperSubtypeProperties.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("keiko.objectMapper")
+open class ObjectMapperSubtypeProperties {
+  var messageRootType: String = "com.netflix.spinnaker.q.Message"
+  var messagePackages: List<String> = listOf("com.netflix.spinnaker.q")
+  var attributeRootType: String = "com.netflix.spinnaker.q.Attribute"
+  var attributePackages: List<String> = listOf("com.netflix.spinnaker.q")
+
+  var extraSubtypes: Map<String, List<String>> = mapOf()
+}

--- a/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/SpringObjectMapperConfigurer.kt
+++ b/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/SpringObjectMapperConfigurer.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.exception.InvalidSubtypeConfigurationException
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AssignableTypeFilter
+import org.springframework.util.ClassUtils
+
+/**
+ * Automates registering subtypes to the queue object mapper by classpath scanning.
+ */
+class SpringObjectMapperConfigurer(
+  private val properties: ObjectMapperSubtypeProperties
+) {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  fun registerSubtypes(mapper: ObjectMapper) {
+    registerSubtypes(mapper, properties.messageRootType, properties.messagePackages)
+    registerSubtypes(mapper, properties.attributeRootType, properties.attributePackages)
+
+    properties.extraSubtypes.entries.forEach {
+      registerSubtypes(mapper, it.key, it.value)
+    }
+  }
+
+  private fun registerSubtypes(mapper: ObjectMapper, rootType: String, subtypePackages: List<String>) {
+    getRootTypeClass(rootType).also { cls ->
+      subtypePackages.forEach { mapper.registerSubtypes(*findSubtypes(cls, it)) }
+    }
+  }
+
+  private fun getRootTypeClass(name: String): Class<*> {
+    return ClassUtils.resolveClassName(name, ClassUtils.getDefaultClassLoader())
+  }
+
+  private fun findSubtypes(clazz: Class<*>, pkg: String): Array<Class<*>> =
+    ClassPathScanningCandidateComponentProvider(false)
+      .apply { addIncludeFilter(AssignableTypeFilter(clazz)) }
+      .findCandidateComponents(pkg)
+      .map {
+        val cls = ClassUtils.resolveClassName(it.beanClassName, ClassUtils.getDefaultClassLoader())
+
+        // Enforce all implementing types to have a JsonTypeName class
+        val serializationName = cls.annotations
+          .filterIsInstance<JsonTypeName>()
+          .firstOrNull()
+          ?.value ?: throw InvalidSubtypeConfigurationException("Subtype ${cls.simpleName} does not have a JsonTypeName")
+
+        log.info("Registering subtype of ${clazz.simpleName}: $serializationName")
+        return@map cls
+      }
+      .toTypedArray()
+}

--- a/keiko-spring/src/main/kotlin/com/netflix/spinnaker/exception/InvalidSubtypeConfigurationException.kt
+++ b/keiko-spring/src/main/kotlin/com/netflix/spinnaker/exception/InvalidSubtypeConfigurationException.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Netflix, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License")
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,13 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.netflix.spinnaker.exception
 
-package com.netflix.spinnaker.config
-
-import org.springframework.boot.context.properties.ConfigurationProperties
-
-@ConfigurationProperties("keiko.queue")
-class QueueProperties {
-  var handlerCorePoolSize: Int = 20
-  var handlerMaxPoolSize: Int = 20
-}
+class InvalidSubtypeConfigurationException(message: String) : IllegalStateException(message)

--- a/keiko-tck/src/main/kotlin/com/netflix/spinnaker/q/TestMessage.kt
+++ b/keiko-tck/src/main/kotlin/com/netflix/spinnaker/q/TestMessage.kt
@@ -16,4 +16,7 @@
 
 package com.netflix.spinnaker.q
 
+import com.fasterxml.jackson.annotation.JsonTypeName
+
+@JsonTypeName("test")
 data class TestMessage(val payload: String) : Message()


### PR DESCRIPTION
* Adds a migrator interface for performing mutations on serialization failures
* Refactors messages & attributes to use `@JsonTypeName`
* Adds `ObjectMapper` configurer to help register subtypes

I merged in the object mapper configuration logic from Keel, which will be necessary in Orca as well. Once this is in place, we should be able to pull Keiko into Orca--provided we write a migrator for getting `MINIMAL_CLASS` Jackson serialization into `NAME`. Can discuss strategy there, since it'll be harder than the FQN migrator.