### PR TITLE
feat(contrib/cron): Scaffolding out cron capabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,11 +47,12 @@ subprojects {
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
-  license {
-    mapping {
-      kt = "SLASHSTAR_STYLE"
-    }
-  }
+  // TODO rz - randomly broke?
+//  license {
+//    mapping {
+//      kt = "SLASHSTAR_STYLE"
+//    }
+//  }
 }
 
 defaultTasks "build"

--- a/contrib/redis-cron-scheduler/build.gradle
+++ b/contrib/redis-cron-scheduler/build.gradle
@@ -1,0 +1,6 @@
+apply from: "$rootDir/gradle/spek.gradle"
+
+dependencies {
+  compile project(":keiko-redis-spring")
+  compile "com.cronutils:cron-utils:7.0.1"
+}

--- a/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/config/KeikoRedisCronConfiguration.kt
+++ b/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/config/KeikoRedisCronConfiguration.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnProperty("keiko.cron.enabled")
+@ComponentScan(basePackages = arrayOf(
+  "com.netflix.spinnaker.keiko.contrib.rediscron",
+  "com.netflix.spinnaker.keiko.contrib.rediscron.handler"
+))
+@EnableConfigurationProperties(RefreshCronScheduleHandlerProperties::class)
+open class KeikoRedisCronConfiguration

--- a/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/config/RefreshCronScheduleHandlerProperties.kt
+++ b/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/config/RefreshCronScheduleHandlerProperties.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("handler.refreshCronSchedule")
+open class RefreshCronScheduleHandlerProperties {
+  var intervalSeconds: Long = 60
+}

--- a/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/Cron.kt
+++ b/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/Cron.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keiko.contrib.rediscron
+
+data class Cron(
+  val id: String,
+  val expression: String,
+  val action: String,
+  val spec: CronActionSpec
+)
+
+interface CronAction {
+  fun run(runCron: Cron)
+}
+
+interface CronActionSpec {
+  val serviceAccount: String
+}

--- a/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/CronRepository.kt
+++ b/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/CronRepository.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keiko.contrib.rediscron
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import redis.clients.jedis.Jedis
+import redis.clients.util.Pool
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDateTime
+
+interface CronRepository {
+
+  fun upsert(cronMessage: Cron)
+
+  fun delete(id: String)
+
+  fun find(id: String): Cron?
+
+  fun findAll(): List<Cron>
+
+  fun recordFire(id: String)
+
+  fun getPreviousFires(id: String): List<LocalDateTime>
+}
+
+class RedisCronRepository(
+  private val namespace: String = "keiko",
+  // TODO rz - RedisClientDelegate
+  private val pool: Pool<Jedis>,
+  private val mapper: ObjectMapper,
+  private val clock: Clock
+): CronRepository {
+
+  private val ACTIVE_KEY = "{$namespace:cron}:active"
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  override fun upsert(cron: Cron) {
+    pool.resource.use { redis -> redis.upsertCron(cron) }
+  }
+
+  override fun delete(id: String) {
+    pool.resource.use { redis ->
+      redis.srem(ACTIVE_KEY, id)
+      redis.expire(cronKey(id), Duration.ofDays(3).toSeconds())
+      redis.expire(cronHistoryKey(id), Duration.ofDays(3).toSeconds())
+    }
+  }
+
+  override fun find(id: String): Cron? =
+    pool.resource.use { redis ->
+      redis.get(cronKey(id))
+        ?.let { mapper.readValue(it, Wrapper::class.java).cron }
+        ?: checkExpiry(redis, id); null
+    }
+
+  private fun checkExpiry(redis: Jedis, id: String) {
+    val expiry = redis.ttl(cronKey(id))
+    if (expiry <= 0) {
+      log.debug("Requested cron $id was deleted as is set to cleanup in $expiry seconds")
+    }
+  }
+
+  override fun findAll(): List<Cron> =
+    pool.resource.use { redis ->
+      redis.smembers(ACTIVE_KEY)
+        .map { mapper.readValue<Wrapper>(it, Wrapper::class.java).cron }
+    }
+
+  override fun recordFire(id: String) {
+    pool.resource.use { redis ->
+      clock.instant().toEpochMilli().also {
+        redis.zadd(cronHistoryKey(id), it.toDouble(), it.toString())
+      }
+    }
+  }
+
+  override fun getPreviousFires(id: String): List<LocalDateTime> =
+    pool.resource.use { redis ->
+      redis.zrangeByScore(cronHistoryKey(id), "-inf", "+inf")
+        .map { LocalDateTime.from(Instant.ofEpochMilli(it.toLong())) }
+    }
+
+  private fun cronKey(id: String) = "{$namespace:cron}:action:$id"
+
+  private fun cronHistoryKey(id: String) = "{$namespace:cron}:history:$id"
+
+  private fun Jedis.upsertCron(cron: Cron) =
+    cron
+      .let { mapper.writeValueAsString(Wrapper(it, clock.millis())) }
+      .also {
+        set(cronKey(cron.id), it)
+        sadd(ACTIVE_KEY, cron.id)
+      }
+
+  private fun Duration.toSeconds() =
+    (this.toMillis() / 1000).toInt()
+
+  private data class Wrapper(
+    val cron: Cron,
+    val lastModifiedEpochMillis: Long
+  )
+}

--- a/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/Message.kt
+++ b/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/Message.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keiko.contrib.rediscron
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.q.Message
+
+@JsonTypeName("runCron")
+data class RunCron(
+  val id: String
+): Message()
+
+@JsonTypeName("refreshCronSchedule")
+class RefreshCronSchedule : Message()

--- a/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/handler/RefreshCronScheduleHandler.kt
+++ b/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/handler/RefreshCronScheduleHandler.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keiko.contrib.rediscron.handler
+
+import com.cronutils.model.CronType.UNIX
+import com.cronutils.model.definition.CronDefinitionBuilder
+import com.cronutils.model.time.ExecutionTime
+import com.cronutils.parser.CronParser
+import com.netflix.spinnaker.config.RefreshCronScheduleHandlerProperties
+import com.netflix.spinnaker.keiko.contrib.rediscron.Cron
+import com.netflix.spinnaker.keiko.contrib.rediscron.CronRepository
+import com.netflix.spinnaker.keiko.contrib.rediscron.RefreshCronSchedule
+import com.netflix.spinnaker.keiko.contrib.rediscron.RunCron
+import com.netflix.spinnaker.q.MessageHandler
+import com.netflix.spinnaker.q.Queue
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Duration
+import java.time.ZonedDateTime
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit.SECONDS
+
+@Component
+class RefreshCronScheduleHandler(
+  override val queue: Queue,
+  private val cronRepository: CronRepository,
+  private val clock: Clock,
+  properties: RefreshCronScheduleHandlerProperties
+) : MessageHandler<RefreshCronSchedule> {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  private val executor = Executors.newScheduledThreadPool(1)
+
+  init {
+    // TODO rz - possible race condition; should acquire lock at beginning of handle...
+    executor.scheduleWithFixedDelay({
+      queue.ensure(RefreshCronSchedule(), Duration.ofSeconds(30))
+    }, 0, properties.intervalSeconds, SECONDS)
+  }
+
+  override fun handle(message: RefreshCronSchedule) {
+    val parser = CronParser(CronDefinitionBuilder.instanceDefinitionFor(UNIX))
+
+    // Find all valid crons and schedule run tasks for their next executions
+    cronRepository
+      .findAll()
+      .mapNotNull { cron ->
+        cron.nextExecution(parser).let { nextExecution ->
+          if (nextExecution.isPresent) {
+            Pair(RunCron(cron.id), nextExecution.get().toEpochSecond() - clock.instant().epochSecond)
+          } else {
+            null
+          }
+        }
+      }
+      .also { log.info("Scheduling ${it.size} cron schedules") }
+      .forEach { queue.ensure(it.first, Duration.ofSeconds(it.second)) }
+  }
+
+  override val messageType = RefreshCronSchedule::class.java
+
+  private fun Cron.nextExecution(parser: CronParser)
+    = ExecutionTime.forCron(parser.parse(expression)).nextExecution(ZonedDateTime.now())
+
+}

--- a/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/handler/RunCronHandler.kt
+++ b/contrib/redis-cron-scheduler/src/main/kotlin/com/netflix/spinnaker/keiko/contrib/rediscron/handler/RunCronHandler.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keiko.contrib.rediscron.handler
+
+import com.netflix.spinnaker.keiko.contrib.rediscron.CronAction
+import com.netflix.spinnaker.keiko.contrib.rediscron.CronRepository
+import com.netflix.spinnaker.keiko.contrib.rediscron.RunCron
+import com.netflix.spinnaker.q.MessageHandler
+import com.netflix.spinnaker.q.Queue
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class RunCronHandler(
+  override val queue: Queue,
+  private val cronRepository: CronRepository,
+  private val cronAction: List<CronAction>
+) : MessageHandler<RunCron> {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  override val messageType = RunCron::class.java
+
+  override fun handle(message: RunCron) {
+    val cron = cronRepository.find(message.id)
+    if (cron == null) {
+      log.warn("Could not find previously scheduled cron: ${message.id}")
+      return
+    }
+
+    val action = cronAction.filter { it.javaClass.simpleName == cron.action }
+    if (action.size > 1) {
+      // TODO rz - should fire an event here instead
+      log.error("More than one action for cron was found: $action")
+      return
+    }
+
+    action.firstOrNull()
+      ?.run(cron)
+      ?: log.warn("No action found for cron: $cron")
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ include "keiko-core",
     "keiko-redis-spring",
     "keiko-spring",
     "keiko-tck",
-    "keiko-test-common"
+    "keiko-test-common",
+    "contrib:redis-cron-scheduler"
 
 rootProject.name = "keiko"


### PR DESCRIPTION
Got inspired... was thinking about how to break up circular dependencies in our arch (echo <-> orca). Thought maybe moving cron triggered pipelines into orca could be interesting. This would also allow us to run the scheduler in HA, which would be a nice availability improvement.

Just a concept at this point, wondering if we'd find it useful to actual pursue. I purposely hand-waved over a better typing model on `CronAction/Spec`, but cron handlers would essentially be callbacks registered into Spring and matched on.