### PR TITLE
feat(redis): Prefetch fingerprints to increase likelihood of acquiring lock

### DIFF
--- a/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
+++ b/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueConfiguration.kt
@@ -79,7 +79,8 @@ class RedisQueueConfiguration {
       deadMessageHandler = deadMessageHandler,
       publisher = publisher,
       ackTimeout = Duration.ofSeconds(redisQueueProperties.ackTimeoutSeconds.toLong()),
-      serializationMigrator = serializationMigrator
+      serializationMigrator = serializationMigrator,
+      prefetchCount = redisQueueProperties.prefetchCount
     )
 
   @Bean

--- a/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueProperties.kt
+++ b/keiko-redis-spring/src/main/kotlin/com/netflix/spinnaker/config/RedisQueueProperties.kt
@@ -23,4 +23,5 @@ class RedisQueueProperties {
   var queueName: String = "keiko.queue"
   var deadLetterQueueName: String = "keiko.queue.deadLetters"
   var ackTimeoutSeconds: Int = 60
+  var prefetchCount: Int = 10
 }


### PR DESCRIPTION
We often see that the queue backs up on ready messages, even though the worker pool isn't filling up. I believe this is due to the poll / lock behavior within keiko. The current behavior is that every instance will fetch the HEAD fingerprint on the queue and fight for a lock on it. If the lock fails, the entire poll cycle is given up on, which means the instance won't be doing anything for at least one cycle. In this PR, I fetch multiple fingerprints off the queue and iterate in order until a lock is acquired. If the list of prefetched fingerprints is exhausted without successfully acquiring a lock, the normal behavior is used (no-op on cycle). This prefetch count should be equal to or more than the number of Orca instances running against the queue.