### PR TITLE
fix(redis): Correctly handle missing message

### DIFF
--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
@@ -415,7 +415,7 @@ private const val READ_MESSAGE = """
 
   -- check for an ack timeout override on the message
   local unackScore = unackDefaultScore
-  if message ~= nil then
+  if type(message) == "string" and message ~= nil then
     local ackTimeoutOverride = tonumber(cjson.decode(message)["ackTimeoutMs"])
     if ackTimeoutOverride ~= nil and unackBaseScore ~= nil then
       unackScore = unackBaseScore + ackTimeoutOverride


### PR DESCRIPTION
```lua
redis.call("DEL", "mymap")
redis.call("HSET", "mymap", "mykey", "myvalue")

local presentValue = redis.call("HGET", "mymap", "mykey")
local missingValue = redis.call("HGET", "mymap", "nope")

redis.call("ECHO", "presentValue: " .. presentValue)
if type(missingValue) == "string" then
  redis.call("ECHO", "missingValue: " .. missingValue)
end
if type(missingValue) == "boolean" then
  redis.call("ECHO", "missingValue: (converted) " .. tostring(missingValue))
end
```

```1523335855.702591 [0 lua] "DEL" "mymap"
1523335855.702603 [0 lua] "HSET" "mymap" "mykey" "myvalue"
1523335855.702629 [0 lua] "HGET" "mymap" "mykey"
1523335855.702638 [0 lua] "HGET" "mymap" "nope"
1523335855.702644 [0 lua] "ECHO" "presentValue: myvalue"
1523335855.702661 [0 lua] "ECHO" "missingValue: (converted) false"```