### PR TITLE
fix(core): Introduce jitter when re-queueing message if executor is full

### DIFF
--- a/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
+++ b/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.time.Clock
+import java.time.Duration
 
 @Configuration
 @EnableConfigurationProperties(QueueProperties::class)
@@ -57,7 +58,17 @@ class QueueConfiguration {
     publisher: EventPublisher,
     queueProperties: QueueProperties,
     deadMessageHandler: DeadMessageCallback
-  ) = QueueProcessor(queue, executor, handlers, activator, publisher, deadMessageHandler, queueProperties.fillExecutorEachCycle)
+  ) = QueueProcessor(
+    queue,
+    executor,
+    handlers,
+    activator,
+    publisher,
+    deadMessageHandler,
+    queueProperties.fillExecutorEachCycle,
+    Duration.ofSeconds(queueProperties.requeueDelaySeconds),
+    Duration.ofSeconds(queueProperties.requeueMaxJitterSeconds)
+  )
 
   @Bean
   fun queueEventPublisher(

--- a/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueProperties.kt
+++ b/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueProperties.kt
@@ -24,4 +24,6 @@ class QueueProperties {
   var handlerCorePoolSize: Int = 20
   var handlerMaxPoolSize: Int = 20
   var fillExecutorEachCycle: Boolean = false
+  var requeueDelaySeconds : Long = 0
+  var requeueMaxJitterSeconds : Long = 0
 }


### PR DESCRIPTION
- include more meaningful log output (message, attempts, delay, etc.)