### PR TITLE
config(kotlin): make QueueProcessor and RedisQueue open

### DIFF
--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -16,6 +16,11 @@
 
 apply plugin: "nebula.kotlin"
 apply plugin: "kotlin-spring"
+apply plugin: "kotlin-allopen"
+
+allOpen {
+  annotation("com.netflix.spinnaker.KotlinOpen")
+}
 
 configurations.all {
   resolutionStrategy {

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/KotlinOpen.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/KotlinOpen.kt
@@ -1,0 +1,3 @@
+package com.netflix.spinnaker
+
+annotation class KotlinOpen

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.q
 
+import com.netflix.spinnaker.KotlinOpen
 import com.netflix.spinnaker.q.metrics.EventPublisher
 import com.netflix.spinnaker.q.metrics.MessageDead
 import com.netflix.spinnaker.q.metrics.HandlerThrewError
@@ -30,6 +31,7 @@ import javax.annotation.PostConstruct
  * The processor that fetches messages from the [Queue] and hands them off to
  * the appropriate [MessageHandler].
  */
+@KotlinOpen
 class QueueProcessor(
   private val queue: Queue,
   private val executor: QueueExecutor<*>,

--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.q.redis
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.google.common.hash.Hashing
+import com.netflix.spinnaker.KotlinOpen
 import com.netflix.spinnaker.q.AttemptsAttribute
 import com.netflix.spinnaker.q.DeadMessageCallback
 import com.netflix.spinnaker.q.MaxAttemptsAttribute
@@ -47,6 +48,7 @@ import java.time.Instant
 import java.time.temporal.TemporalAmount
 import java.util.*
 
+@KotlinOpen
 class RedisQueue(
   private val queueName: String,
   private val pool: Pool<Jedis>,


### PR DESCRIPTION
The kotlin-spring plugin only applies all-open to classes that have Spring
annotations, but QueueProcessor and RedisQueue are not explicitly annotated.

Let's add a new annotation, KotlinOpen and configure the all-open plugin
to look for classes annotated with it.