### PR TITLE
feat(core): Support queue partitioning

### DIFF
--- a/keiko-core/build.gradle
+++ b/keiko-core/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   compile "com.fasterxml.jackson.core:jackson-annotations:${spinnaker.version("jackson")}"
   compile "com.fasterxml.jackson.core:jackson-databind:${spinnaker.version("jackson")}"
   compile "org.springframework:spring-context:${spinnaker.version("spring")}"
+  compile "com.google.guava:guava:${spinnaker.version("guava")}"
 
   testCompile project(":keiko-test-common")
 }

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
@@ -133,5 +133,5 @@ class QueueProcessor(
 
   @PostConstruct
   fun confirmQueueType() =
-    log.info("Using ${queue.javaClass.simpleName} queue")
+    log.info("Using ${queue.javaClass.simpleName}")
 }

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/PartitionAttribute.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/PartitionAttribute.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.partition
+
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.netflix.spinnaker.q.Attribute
+
+@JsonTypeName("partition")
+data class PartitionAttribute(val id: String) : Attribute

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/PartitionedQueue.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/PartitionedQueue.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.partition
+
+import com.netflix.spinnaker.q.DeadMessageCallback
+import com.netflix.spinnaker.q.Message
+import com.netflix.spinnaker.q.Queue
+import com.netflix.spinnaker.q.QueueCallback
+import java.time.temporal.TemporalAmount
+
+/**
+ * Delegates to a [QueueSelector] to allow transparent queue partitioning.
+ *
+ * Note: This queue type supercedes any values for [queueName], [ackTimeout], and
+ * [deadMessageHandlers] that may be provided by the underlying queues defined
+ * within [QueueSelector].
+ */
+class PartitionedQueue(
+  private val queueSelector: QueueSelector,
+  override val ackTimeout: TemporalAmount,
+  override val deadMessageHandlers: List<DeadMessageCallback>
+) : Queue {
+
+  override fun poll(callback: QueueCallback) {
+    queueSelector.forPoll().poll(callback)
+  }
+
+  override fun push(message: Message, delay: TemporalAmount) {
+    queueSelector.forMessage(message).push(message, delay)
+  }
+
+  override fun reschedule(message: Message, delay: TemporalAmount) {
+    queueSelector.forMessage(message).reschedule(message, delay)
+  }
+
+  override fun ensure(message: Message, delay: TemporalAmount) {
+    queueSelector.forMessage(message).ensure(message, delay)
+  }
+}

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/PriorityQueueSelector.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/PriorityQueueSelector.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.partition
+
+import com.netflix.spinnaker.q.Message
+import com.netflix.spinnaker.q.Queue
+import java.security.SecureRandom
+
+/**
+ * Allows messages to be prioritized across weighted queues.
+ *
+ * A [PartitionWeightMapper] can be provided to translate between application-specific priorities
+ * and the [WeightedQueue] weight value.
+ */
+class PriorityQueueSelector(
+  private val queues: List<WeightedQueue>,
+  customPartitionWeightMapper: PartitionWeightMapper? = null
+) : QueueSelector {
+
+  companion object {
+    private val defaultPartitionWeightMapper: PartitionWeightMapper = { partitionAttribute ->
+      partitionAttribute.id.toIntOrNull()
+    }
+  }
+
+  private val rand = SecureRandom()
+  private val weightSum = queues.map { it.weight }.sum()
+  private val highestPriorityQueue: Queue
+  private val defaultQueue: Queue
+  private val partitionWeightMapper = customPartitionWeightMapper ?: defaultPartitionWeightMapper
+
+  init {
+    if (queues.isEmpty()) {
+      throw IllegalArgumentException("At least one queue must be provided")
+    }
+    if (queues.filter { it.default }.size != 1) {
+      throw IllegalArgumentException("One queue must be flagged as default")
+    }
+    highestPriorityQueue = queues.sortedByDescending { it.weight }.first().queue
+    defaultQueue = queues.first { it.default }.queue
+  }
+
+  override fun forPoll() = selectQueue(rand.nextInt(weightSum), queues.iterator())
+
+  private tailrec fun selectQueue(r: Int, iterator: Iterator<WeightedQueue>): Queue {
+    if (!iterator.hasNext()) {
+      // We should never get here, but if we do, just read off the highest priority queue
+      return highestPriorityQueue
+    }
+    val q = iterator.next()
+    if ((r - q.weight) >= 0) {
+      return q.queue
+    }
+    return selectQueue(r, iterator)
+  }
+
+  override fun forMessage(message: Message): Queue {
+    val partition = message.getAttribute<PartitionAttribute>()
+      ?.let { partitionWeightMapper(it) }
+      ?: return defaultQueue
+
+    return queues.firstOrNull { it.weight == partition }?.queue ?: defaultQueue
+  }
+}
+
+/**
+ * @param queue the actual queue implementation
+ * @param weight the probability the queue will be selected; higher number has a higher priority
+ * @param default if true, this queue will be chosen on writes if a [PartitionAttribute] is
+ *                unavailable or does not match any other queues
+ */
+data class WeightedQueue(
+  val queue: Queue,
+  val weight: Int,
+  val default: Boolean
+)
+
+/**
+ * Provides a way for applications to map arbitrarily named priorities to the weight values
+ * associated with a weighted queue. If the mapper cannot map a particular [PartitionAttribute],
+ * and has no definition of a default value, null should be returned.
+ */
+typealias PartitionWeightMapper = (PartitionAttribute) -> Int?

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/QueueSelector.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/QueueSelector.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.partition
+
+import com.netflix.spinnaker.q.Message
+import com.netflix.spinnaker.q.Queue
+
+/**
+ * Provides an abstraction around selecting what queue to use for a particular queue operation.
+ */
+interface QueueSelector {
+  fun forPoll(): Queue
+  fun forMessage(message: Message): Queue
+}

--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/RoundRobinQueueSelector.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/partition/RoundRobinQueueSelector.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.partition
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.google.common.hash.Hashing
+import com.netflix.spinnaker.q.Message
+import com.netflix.spinnaker.q.Queue
+import java.lang.Math.abs
+import java.nio.charset.StandardCharsets.UTF_8
+
+/**
+ * Delegates to a pool of queues, reading messages out in a round robin order.
+ */
+class RoundRobinQueueSelector(
+  private val queues: List<Queue>,
+  fallbackPartitionProvider: RoundRobinPartitionProvider? = null
+) : QueueSelector {
+
+  companion object {
+    private val hashObjectMapper = ObjectMapper().apply {
+      enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+    }
+
+    private val defaultPartitionProvider: RoundRobinPartitionProvider = { message ->
+      hashObjectMapper.convertValue(message, MutableMap::class.java)
+        .apply { remove("attributes") }
+        .let {
+          Hashing
+            .murmur3_32()
+            .hashString(hashObjectMapper.writeValueAsString(it), UTF_8)
+            .asInt()
+        }
+    }
+  }
+
+  private var iterable: Iterator<Queue> = queues.iterator()
+  private val size = queues.size
+  private val partitionProvider = fallbackPartitionProvider ?: defaultPartitionProvider
+
+  init {
+    if (queues.isEmpty()) {
+      throw IllegalArgumentException("At least one queue must be provided")
+    }
+  }
+
+  override fun forPoll(): Queue {
+    if (!iterable.hasNext()) {
+      iterable = queues.iterator()
+    }
+    return iterable.next()
+  }
+
+  override fun forMessage(message: Message) = queues[message.partition()]
+
+  private fun Message.partition(): Int =
+    (getAttribute<PartitionAttribute>()?.id?.hashCode() ?: partitionProvider(this))
+      .let { abs(it % size) }
+}
+
+typealias RoundRobinPartitionProvider = (m: Message) -> Int

--- a/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/partition/PriorityQueueSelectorTest.kt
+++ b/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/partition/PriorityQueueSelectorTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.partition
+
+import com.netflix.spinnaker.q.Queue
+import com.netflix.spinnaker.q.SimpleMessage
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.reset
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+
+object PriorityQueueSelectorTest : Spek({
+
+  describe("a priority queue selector") {
+
+    val queue1: Queue = mock()
+    val queue2: Queue = mock()
+
+    fun resetMocks() = reset(
+      queue1,
+      queue2
+    )
+
+    describe("selecting a queue for polling") {
+      val subject = PriorityQueueSelector(listOf(
+        WeightedQueue(queue = queue1, weight = 2, default = false),
+        WeightedQueue(queue = queue2, weight = 1, default = true)
+      ))
+
+      afterGroup(::resetMocks)
+
+      on("the multiple polling cycles") {
+        val results = mutableListOf<Queue>()
+        (0..9).forEach { results.add(subject.forPoll()) }
+
+        it("mostly returns higher weighted queues") {
+          val queue1Size = results.filter { it == queue1 }.size
+          val queue2Size = results.filter { it == queue2 }.size
+
+          // Queue1 will be returned 2/3 of the time
+          assertThat(queue1Size).isGreaterThan(queue2Size)
+        }
+      }
+    }
+
+    describe("selecting a queue by message") {
+      val subject = PriorityQueueSelector(listOf(
+        WeightedQueue(queue = queue1, weight = 2, default = false),
+        WeightedQueue(queue = queue2, weight = 1, default = true)
+      ))
+
+      afterGroup(::resetMocks)
+
+      given("a message without partition attribute") {
+        val results = mutableListOf<Queue>()
+        val message = SimpleMessage("hello")
+
+        on("multiple select invocations") {
+          (0..9).forEach { results.add(subject.forMessage(message)) }
+
+          it("returns the same queue each time") {
+            assertThat(results.toSet()).hasSize(1)
+          }
+        }
+      }
+
+      given("a message with a partition attribute") {
+        val results = mutableListOf<Queue>()
+        val message = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("world"))
+        }
+
+        on("multiple select invocations") {
+          (0..9).forEach { results.add(subject.forMessage(message)) }
+
+          it("returns the same queue each time") {
+            assertThat(results.toSet()).hasSize(1)
+          }
+        }
+      }
+
+      given("two messages with different partitions") {
+        val message1 = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("1"))
+        }
+        val message2 = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("2"))
+        }
+
+        on("select for both messages") {
+          val message1Queue = subject.forMessage(message1)
+          val message2Queue = subject.forMessage(message2)
+
+          it("returns different queues") {
+            assertThat(message1Queue).isNotEqualTo(message2Queue)
+          }
+        }
+      }
+    }
+  }
+})

--- a/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/partition/RoundRobinQueueSelectorTest.kt
+++ b/keiko-core/src/test/kotlin/com/netflix/spinnaker/q/partition/RoundRobinQueueSelectorTest.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.q.partition
+
+import com.netflix.spinnaker.q.Queue
+import com.netflix.spinnaker.q.SimpleMessage
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.reset
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+
+object RoundRobinQueueSelectorTest : Spek({
+
+  describe("a round robin queue selector") {
+
+    val queue1: Queue = mock()
+    val queue2: Queue = mock()
+
+    fun resetMocks() = reset(
+      queue1,
+      queue2
+    )
+
+    describe("selecting a queue for polling") {
+      val subject = RoundRobinQueueSelector(listOf(queue1, queue2))
+
+      afterGroup(::resetMocks)
+
+      on("the first polling cycle") {
+        val result = subject.forPoll()
+
+        it("it returns the first queue") {
+          assertThat(result).isEqualTo(queue1)
+        }
+      }
+
+      on("the second polling cycle") {
+        val result = subject.forPoll()
+
+        it("returns the second queue") {
+          assertThat(result).isEqualTo(queue2)
+        }
+      }
+
+      on("the third polling cycle") {
+        val result = subject.forPoll()
+
+        it("returns the first queue again") {
+          assertThat(result).isEqualTo(queue1)
+        }
+      }
+    }
+
+    describe("default partition provider") {
+      val subject = RoundRobinQueueSelector(listOf(queue1, queue2))
+
+      afterGroup(::resetMocks)
+
+      given("a message without partition attribute") {
+        val results = mutableListOf<Queue>()
+        val message = SimpleMessage("hello")
+
+        on("multiple select invocations") {
+          (0..9).forEach { results.add(subject.forMessage(message)) }
+
+          it("returns the same queue each time") {
+            assertThat(results.toSet()).hasSize(1)
+          }
+        }
+      }
+
+      given("a message with a partition attribute") {
+        val results = mutableListOf<Queue>()
+        val message = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("world"))
+        }
+
+        on("multiple select invocations") {
+          (0..9).forEach { results.add(subject.forMessage(message)) }
+
+          it("returns the same queue each time") {
+            assertThat(results.toSet()).hasSize(1)
+          }
+        }
+      }
+
+      given("two messages with different partitions") {
+        val message1 = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("1"))
+        }
+        val message2 = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("2"))
+        }
+
+        on("select for both messages") {
+          val message1Queue = subject.forMessage(message1)
+          val message2Queue = subject.forMessage(message2)
+
+          it("returns different queues") {
+            assertThat(message1Queue).isNotEqualTo(message2Queue)
+          }
+        }
+      }
+    }
+
+    describe("a custom partition provider") {
+      val subject = RoundRobinQueueSelector(
+        listOf(queue1, queue2),
+        fallbackPartitionProvider = { 1 }
+      )
+
+      afterGroup(::resetMocks)
+
+      given("a message without partition attribute") {
+        val results = mutableListOf<Queue>()
+        val message = SimpleMessage("hello")
+
+        on("multiple select invocations") {
+          (0..9).forEach { results.add(subject.forMessage(message)) }
+
+          it("returns the same queue each time") {
+            assertThat(results.toSet()).hasSize(1)
+          }
+        }
+      }
+
+      given("a message with a partition attribute") {
+        val results = mutableListOf<Queue>()
+        val message = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("world"))
+        }
+
+        on("multiple select invocations") {
+          (0..9).forEach { results.add(subject.forMessage(message)) }
+
+          it("returns the same queue each time") {
+            assertThat(results.toSet()).hasSize(1)
+          }
+        }
+      }
+
+      given("two messages with different partitions") {
+        val message1 = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("1"))
+        }
+        val message2 = SimpleMessage("hello").apply {
+          setAttribute(PartitionAttribute("2"))
+        }
+
+        on("select for both messages") {
+          val message1Queue = subject.forMessage(message1)
+          val message2Queue = subject.forMessage(message2)
+
+          it("returns the different queues") {
+            assertThat(message1Queue).isNotEqualTo(message2Queue)
+          }
+        }
+      }
+
+      given("two messages without partition attributes") {
+        val message1 = SimpleMessage("hello")
+        val message2 = SimpleMessage("world")
+
+        on("select for both messages") {
+          val message1Queue = subject.forMessage(message1)
+          val message2Queue = subject.forMessage(message2)
+
+          it("returns the different queues") {
+            assertThat(message1Queue).isEqualTo(message2Queue)
+          }
+        }
+      }
+    }
+  }
+})

--- a/keiko-redis/build.gradle
+++ b/keiko-redis/build.gradle
@@ -6,7 +6,6 @@ dependencies {
   compile "com.fasterxml.jackson.core:jackson-databind:${spinnaker.version("jackson")}"
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:${spinnaker.version("jackson")}"
   compile "org.funktionale:funktionale-partials:1.1"
-  compile "com.google.guava:guava:${spinnaker.version("guava")}"
 
   testCompile project(":keiko-tck")
   testCompile "com.netflix.spinnaker.kork:kork-jedis-test:${spinnaker.version("kork")}"


### PR DESCRIPTION
I wanted to add built-in capability for a single `QueueProcessor` to read from multiple underlying queues. I just hammered out a couple implementations to illustrate how it may work.

A `QueueSelector` offers different strategies for how the `PartitionedQueue` will select what queue to interact with. While a `QueueSelector` can implement any kind of logic, the two I wrote use a `PartitionAttribute` to (optionally) select which queue to write to. In both implementations, the write operations will consistently resolve to the same queue given the same message or `PartitionAttribute`.

* `RoundRobinQueueSelector` will poll out of the queues in a round robin order.
* `PriorityQueueSelector` uses weighted percentiles to determine which queue to poll from.

What I'd like to do with this is setup a Redis Cluster and then we could spread our queue implementation across 3 Redis servers, which would greatly reduce the blast radius if one Redis instance were to go down.

WDYT? Hot / cold?