### PR TITLE
Supply default QueueExecutor bean

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.parallel=true
-
-kotlinVersion=1.2.41
+kotlinVersion=1.2.61
 junitVersion=1.2.0
 spekVersion=1.1.5

--- a/gradle/kotlin.gradle
+++ b/gradle/kotlin.gradle
@@ -39,7 +39,3 @@ compileKotlin {
     jvmTarget = "1.8"
   }
 }
-
-kapt {
-  mapDiagnosticLocations = true
-}

--- a/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
+++ b/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
@@ -56,6 +56,20 @@ class QueueConfiguration {
     }
 
   @Bean
+  fun queueExecutor(messageHandlerPool: ThreadPoolTaskExecutor) =
+    object : QueueExecutor<ThreadPoolTaskExecutor>(messageHandlerPool) {
+      override fun hasCapacity() =
+        executor.threadPoolExecutor.run {
+          activeCount < maximumPoolSize
+        }
+
+      override fun availableCapacity() =
+        executor.threadPoolExecutor.run {
+          maximumPoolSize - activeCount
+        }
+    }
+
+  @Bean
   fun queueProcessor(
     queue: Queue,
     executor: QueueExecutor<*>,

--- a/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
+++ b/keiko-spring/src/main/kotlin/com/netflix/spinnaker/config/QueueConfiguration.kt
@@ -56,6 +56,7 @@ class QueueConfiguration {
     }
 
   @Bean
+  @ConditionalOnMissingBean(QueueExecutor::class)
   fun queueExecutor(messageHandlerPool: ThreadPoolTaskExecutor) =
     object : QueueExecutor<ThreadPoolTaskExecutor>(messageHandlerPool) {
       override fun hasCapacity() =


### PR DESCRIPTION
Not sure why we weren't doing this as it's necessary to use keiko-spring