### PR TITLE
fix(core): Revert to a countdown executor fill strategy

### DIFF
--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
@@ -57,7 +57,7 @@ class QueueProcessor(
     ifEnabled {
       if (executor.hasCapacity()) {
         if (fillExecutorEachCycle) {
-          while (executor.hasCapacity()) {
+          executor.availableCapacity().downTo(1).forEach {
             pollOnce()
           }
         } else {


### PR DESCRIPTION
`hasCapacity` has a neat property of thrashing a queue if there's not enough work to actually fill the executor.