### PR TITLE
fix(redis): Not all locales use dot (.) as decimal separator

### DIFF
--- a/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
+++ b/keiko-redis/src/main/kotlin/com/netflix/spinnaker/q/redis/RedisQueue.kt
@@ -61,6 +61,7 @@ import java.time.Duration
 import java.time.Duration.ZERO
 import java.time.Instant
 import java.time.temporal.TemporalAmount
+import java.util.Locale
 import java.util.Optional
 
 @KotlinOpen
@@ -329,8 +330,8 @@ class RedisQueue(
       score().toString(),
       10.toString(), // TODO rz - make this configurable.
       lockTtlSeconds.toString(),
-      format("%f", score(ackTimeout)),
-      format("%f", score())
+      format(Locale.US, "%f", score(ackTimeout)),
+      format(Locale.US, "%f", score())
     ))
     if (response is List<*>) {
       return Triple(


### PR DESCRIPTION
If you run Orca on a JVM using a locale that don't use dot (.) as the decimal separator, the Lua interpreter in redis complains that the input is not a number:

```
redis.clients.jedis.exceptions.JedisDataException: ERR Error running script (call to f_065ce216750fa703e6f60302be400d42676231a0): @user_script:45: user_script:45: bad argument #2 to 'format' (number expected, got string)
```

This commit fixes this by forcing US locale on the input to the Lua script.