### PR TITLE
fix(sql): increase batch size for SqlQueue::containsMessage

### DIFF
--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -166,7 +166,7 @@ class SqlQueue(
   }
 
   override fun containsMessage(predicate: (Message) -> Boolean): Boolean {
-    val batchSize = 100
+    val batchSize = 2000
     var found = false
     var lastId = "0"
 


### PR DESCRIPTION
It seems that a batchSize of 100 is small enough to allow the zombie check in
orca to flag wrong things.