### PR TITLE
chore(java11): Compile with Java 11 (but targeting Java 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -27,4 +32,4 @@ jobs:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: ./gradlew -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace
+        run: ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle
@@ -19,4 +24,4 @@ jobs:
     - name: Build
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-      run: ./gradlew build javadoc
+      run: ./gradlew -PenableCrossCompilerPlugin=true build javadoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -37,7 +42,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
       - name: Release build
         if: steps.release_info.outputs.IS_CANDIDATE == 'false'
         env:
@@ -45,7 +50,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/build.gradle
+++ b/build.gradle
@@ -48,15 +48,6 @@ subprojects {
     implementation("org.slf4j:slf4j-api")
     testRuntimeOnly("org.slf4j:slf4j-nop")
   }
-
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
-
-//  license {
-//    mapping {
-//      kt = "SLASHSTAR_STYLE"
-//    }
-//  }
 }
 
 apply(from: "$rootDir/gradle/ktlint-root.gradle")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 enablePublishing=false
 korkVersion=7.13.0
-spinnakerGradleVersion=7.0.2
+spinnakerGradleVersion=7.10.0

--- a/keiko-core/build.gradle
+++ b/keiko-core/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   api "org.springframework:spring-context"
 
   implementation "com.netflix.spectator:spectator-api"
+  implementation "javax.annotation:javax.annotation-api"
 
   testImplementation project(":keiko-test-common")
 }

--- a/keiko-tck/src/main/kotlin/com/netflix/spinnaker/q/metrics/MonitorableQueueTest.kt
+++ b/keiko-tck/src/main/kotlin/com/netflix/spinnaker/q/metrics/MonitorableQueueTest.kt
@@ -29,15 +29,15 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.reset
 import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
+import java.io.Closeable
+import java.time.Clock
+import java.time.Duration
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
-import java.io.Closeable
-import java.time.Clock
-import java.time.Duration
 
 /**
  * An compatibility test for implementations of [MonitorableQueue].
@@ -205,7 +205,9 @@ abstract class MonitorableQueueTest<out Q : MonitorableQueue>(
           .let { event ->
             if (event is MessageProcessing) {
               assertThat(event.payload).isEqualTo(TestMessage("a"))
-              assertThat(event.lag).isEqualTo(Duration.ofSeconds(1))
+              // Redis queues only store millisecond precision (in AbstractRedisQueue#score)
+              // In Java 9+, we should instead use event.lag.truncatedTo(MILLIS)
+              assertThat(event.lag.toMillis()).isEqualTo(Duration.ofSeconds(1).toMillis())
             }
           }
       }


### PR DESCRIPTION
Additional changes:

* `MonitorableQueueTest` is another victim of `Instant.now()` returning nanosecond precision in Java 11. The Redis queues don't support this level of precision, so we have to remove that precision before doing equality comparisons. This is just a testing issue and I can't imagine it would cause issues with production code.

* Removed the source/target versions from build.gradle. These are applied by the base plugin now.

* Added the javax.annotation JAR, since it isn't bundled with the JVM in Java 11. This isn't needed if you're using the cross-compiler, but I don't expect developers to leave that on all the time. And we'll need this when we move to Java 11 proper anyway.