### PR TITLE
chore(queue): add an informative toString() in SqlQueue

### DIFF
--- a/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
+++ b/keiko-core/src/main/kotlin/com/netflix/spinnaker/q/QueueProcessor.kt
@@ -137,5 +137,5 @@ class QueueProcessor(
 
   @PostConstruct
   fun confirmQueueType() =
-    log.info("Using ${queue.javaClass.simpleName} queue")
+    log.info("Using queue $queue")
 }

--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -125,9 +125,11 @@ class SqlQueue(
   private val writeRetryBackoffMax = max(sqlRetryProperties.transactions.backoffMs + 50, 100)
 
   init {
-    log.info("Configured $javaClass queue: $queueName")
+    log.info("Configured queue $this")
     initTables()
   }
+
+  override fun toString(): String = "SqlQueue(queueName=$sanitizedName, poolName=$poolName)"
 
   override fun readState(): QueueState {
     withPool(poolName) {


### PR DESCRIPTION
The QueueProcessor will now display something like `Using queue SqlQueue(queueName=default, poolName=default)`, which can be useful when there are multiple SqlQueue beans around connected to different sql pools