### PR TITLE
fix(sql): fix typo in `withPool`

### DIFF
--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/SqlQueue.kt
@@ -773,7 +773,7 @@ class SqlQueue(
   }
 
   private fun ackMessage(fingerprint: String) {
-    withPool("poolName") {
+    withPool(poolName) {
       withRetry(WRITE) {
         jooq.deleteFrom(unackedTable)
           .where(fingerprintField.eq(fingerprint))


### PR DESCRIPTION
We obviously want to refer to this queue's poolName, not the literal "poolName"...