### PR TITLE
fix(sql): PostgreSQL compatibility for keiko-sql

### DIFF
--- a/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/util/Util.kt
+++ b/keiko-sql/src/main/kotlin/com/netflix/spinnaker/q/sql/util/Util.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Apple, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.q.sql.util
+
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+
+fun currentSchema(context: DSLContext): String {
+  return context.fetch("select current_schema()")
+    .getValue(0, DSL.field("current_schema")).toString()
+}
+
+fun createTableLike(newTable: String, templateTable: String, context: DSLContext) {
+  var sql = "CREATE TABLE IF NOT EXISTS "
+  sql += when (context.dialect()) {
+    SQLDialect.POSTGRES -> {
+      val cs = currentSchema(context)
+      "$cs.$newTable ( LIKE $cs.$templateTable INCLUDING ALL )"
+    }
+    else -> "$newTable LIKE $templateTable"
+  }
+  context.execute(sql)
+}
+
+// Allows insertion of virtual Postgres values on conflict, similar to MySQLDSL.values
+fun <T> excluded(values: Field<T>): Field<T> {
+  return DSL.field("excluded.{0}", values.dataType, values)
+}

--- a/keiko-sql/src/main/resources/db/changelog/20190822-initial-schema.yml
+++ b/keiko-sql/src/main/resources/db/changelog/20190822-initial-schema.yml
@@ -2,6 +2,9 @@ databaseChangeLog:
   - changeSet:
       id: create-keiko-queue-table-v1
       author: afeldman
+      validCheckSum:
+        # Original changeset checksum
+        - 8:551ab623136d3c624d7fd4928d0f4c51
       changes:
         - createTable:
             tableName: keiko_v1_queue_template
@@ -19,7 +22,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: delivery
-                  type: bigint(13)
+                  type: bigint
                   constraints:
                     nullable: false
               - column:
@@ -175,6 +178,9 @@ databaseChangeLog:
   - changeSet:
       id: create-keiko-dlq-table-v1
       author: afeldman
+      validCheckSum:
+        # Original changeset checksum
+        - 8:7b2c146b7f0ff7de56fdb729c8e87277
       changes:
         - createTable:
             tableName: keiko_v1_dlq_template
@@ -192,7 +198,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: updated_at
-                  type: bigint(13)
+                  type: bigint
                   constraints:
                     nullable: false
               - column:
@@ -233,13 +239,16 @@ databaseChangeLog:
   - changeSet:
       id: add-keiko-queue-messages-updated-col
       author: afeldman
+      validCheckSum:
+        # Original changeset checksum
+        - 8:53370973bc79095573dfe46d41cffae7
       changes:
       - addColumn:
           tableName: keiko_v1_messages_template
           columns:
             - column:
                 name: updated_at
-                type: bigint(13)
+                type: bigint
                 defaultValue: 0
                 constraints:
                   nullable: false


### PR DESCRIPTION
This change includes the following:

- Removing bigint display qualifiers - these are MySQL specific, and display-only
- A number of queries used MySQL-specific upsert features.  These have been expanded with PostgreSQL-compatible varieties.
- A small helper has been added to handle the dynamic Keiko queue table creation for PostgreSQL
- A helper has been added to make use of Postgres's "excluded" conflict feature for inserts